### PR TITLE
add a space before /> since some browser can not parse it correctly.

### DIFF
--- a/frontend/views/layouts/main.php
+++ b/frontend/views/layouts/main.php
@@ -84,7 +84,7 @@ $emojify = EmojifyAsset::register($this);
             class="glyphicon glyphicon-repeat"></span></button>
     <button type="button" class="btn btn-default" id="pageQrcode" title="本页二维码"><span
             class="glyphicon glyphicon-qrcode"></span>
-        <img class="qrcode" width="130" height="130" src="<?= Url::to(['/site/qrcode', 'url' => Yii::$app->request->absoluteUrl])?>"/>
+        <img class="qrcode" width="130" height="130" src="<?= Url::to(['/site/qrcode', 'url' => Yii::$app->request->absoluteUrl])?>" />
     </button>
     <button type="button" class="btn btn-default" id="goBottom" title="去底部"><span
             class="glyphicon glyphicon-arrow-down"></span></button>


### PR DESCRIPTION
在chrome上, 竖条工具栏的的二维码有显示不正确. 在/>前面增加空格就能解决问题.