### PR TITLE
fix error: Non-static method frontend\modules\tweet\models\Tweet::fin…

### DIFF
--- a/frontend/modules/tweet/models/Tweet.php
+++ b/frontend/modules/tweet/models/Tweet.php
@@ -43,7 +43,7 @@ class Tweet extends Post
      * @return array|null|\yii\db\ActiveRecord|static
      * @throws NotFoundHttpException
      */
-    public function findModel($id, $condition = '')
+    public static function findModel($id, $condition = '')
     {
         if (!$model = Yii::$app->cache->get('topic' . $id)) {
             $model = static::find()


### PR DESCRIPTION
fix error: Non-static method frontend\modules\tweet\models\Tweet::findModel() should not be called statically