### PR TITLE
更改role和status的显示方式

### DIFF
--- a/backend/views/user/_form.php
+++ b/backend/views/user/_form.php
@@ -1,5 +1,7 @@
 <?php
 
+use common\models\User;
+use kartik\select2\Select2;
 use yii\helpers\Html;
 use yii\widgets\ActiveForm;
 
@@ -12,14 +14,21 @@ use yii\widgets\ActiveForm;
 
     <?php $form = ActiveForm::begin(); ?>
 
-    <?= $form->field($model, 'role')->textInput() ?>
+    <?= $form->field($model, 'role')->widget(Select2::classname(), [
+        'data' => User::getRoleList(),
+        'options' => ['placeholder' => '选择一个权限',  'hideSearch' => true,],
+    ]);
+    ?>
 
-    <?= $form->field($model, 'status')->textInput() ?>
+    <?= $form->field($model, 'status')->widget(Select2::classname(), [
+        'data' => User::getStatusList(),
+        'options' => ['placeholder' => '选择一个状态',  'hideSearch' => true,],
+    ]);
+    ?>
 
     <div class="form-group">
         <?= Html::submitButton($model->isNewRecord ? 'Create' : 'Update', ['class' => $model->isNewRecord ? 'btn btn-success' : 'btn btn-primary']) ?>
     </div>
 
     <?php ActiveForm::end(); ?>
-
 </div>

--- a/backend/views/user/index.php
+++ b/backend/views/user/index.php
@@ -1,5 +1,6 @@
 <?php
 
+use common\models\User;
 use yii\helpers\Html;
 use yii\grid\GridView;
 
@@ -31,7 +32,12 @@ $this->params['breadcrumbs'][] = $this->title;
             // 'password_reset_token',
             // 'email:email',
             // 'tagline',
-             'role',
+             [
+                 'attribute' => 'role',
+                 'value' => function($model) {
+                     return User::getRole($model->role)['name'];
+                 },
+             ],
             // 'status',
              'created_at:datetime',
              'updated_at:datetime',

--- a/common/models/User.php
+++ b/common/models/User.php
@@ -348,4 +348,37 @@ class User extends ActiveRecord implements IdentityInterface
         ];
         return $data[$role];
     }
+
+    public static function getRoleList()
+    {
+        return [
+            self::ROLE_ADMIN => '高级会员',
+            self::ROLE_USER => '会员',
+            self::ROLE_SUPER_ADMIN => '管理员',
+        ];
+    }
+
+    public static function getStatus($status)
+    {
+        $data = [
+            self::STATUS_DELETED => [
+                'name' => '已删除',
+                'color' => 'danger',
+            ],
+            self::STATUS_ACTIVE => [
+                'name' => '正常',
+                'color' => 'default',
+            ],
+        ];
+
+        return $data[$status];
+    }
+
+    public static function getStatusList()
+    {
+        return [
+            self::STATUS_DELETED => '已删除',
+            self::STATUS_ACTIVE => '正常',
+        ];
+    }
 }


### PR DESCRIPTION
后台的"用户管理", role和status显示成对应的文字描述, 而不是数字, 增加可读性.